### PR TITLE
Add save summary watcher and dashboard info

### DIFF
--- a/lib/src/core/save/save_models.dart
+++ b/lib/src/core/save/save_models.dart
@@ -43,6 +43,13 @@ class SaveGameSummary {
     this.season,
     this.year,
     this.uniqueId,
+    this.dayOfWeek,
+    this.dailyLuck,
+    this.weatherIcon,
+    this.isRaining,
+    this.isLightning,
+    this.isSnowing,
+    this.isDebrisWeather,
   });
 
   final String? farmName;
@@ -52,5 +59,12 @@ class SaveGameSummary {
   final String? season;
   final int? year;
   final String? uniqueId;
+  final int? dayOfWeek;
+  final double? dailyLuck;
+  final String? weatherIcon;
+  final bool? isRaining;
+  final bool? isLightning;
+  final bool? isSnowing;
+  final bool? isDebrisWeather;
 }
 

--- a/lib/src/core/save/save_parser.dart
+++ b/lib/src/core/save/save_parser.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
@@ -35,8 +36,20 @@ class SaveParser {
       final moneyStr = _t(['player', 'money']);
       final money = int.tryParse(moneyStr ?? '');
       final day = int.tryParse(_t(['dayOfMonth']) ?? '');
-      final season = _t(['season']);
+      final season = _t(['season']) ?? _t(['currentSeason']);
       final year = int.tryParse(_t(['year']) ?? '');
+      final dayOfWeek = int.tryParse(
+            _t(['dayOfWeek']) ?? _t(['currentDayOfWeek']) ?? _t(['player', 'dayOfWeek']) ?? '',
+          );
+      final luckStr = _t(['player', 'dailyLuck']) ?? _t(['dailyLuck']);
+      final dailyLuck = double.tryParse(luckStr ?? '');
+      final weatherIcon = _t(['weatherIcon']);
+      final isRaining = _parseBool(_t(['isRaining']) ?? _t(['player', 'isRaining']));
+      final isLightning =
+          _parseBool(_t(['isLightning']) ?? _t(['player', 'isLightning']));
+      final isSnowing = _parseBool(_t(['isSnowing']) ?? _t(['player', 'isSnowing']));
+      final isDebris =
+          _parseBool(_t(['isDebrisWeather']) ?? _t(['player', 'isDebrisWeather']));
 
       return SaveGameSummary(
         farmName: farmName,
@@ -45,6 +58,13 @@ class SaveParser {
         dayOfMonth: day,
         season: season,
         year: year,
+        dayOfWeek: dayOfWeek,
+        dailyLuck: dailyLuck,
+        weatherIcon: weatherIcon,
+        isRaining: isRaining,
+        isLightning: isLightning,
+        isSnowing: isSnowing,
+        isDebrisWeather: isDebris,
       );
     } catch (_) {
       return null;
@@ -65,6 +85,65 @@ class SaveParser {
     }
     final text = node.text.trim();
     return text.isEmpty ? null : text;
+  }
+
+  static bool? _parseBool(String? text) {
+    if (text == null) return null;
+    final lower = text.trim().toLowerCase();
+    if (lower == 'true' || lower == '1') return true;
+    if (lower == 'false' || lower == '0') return false;
+    return null;
+  }
+
+  /// 指定フォルダのセーブファイル更新を監視し、サマリーをストリームで返す。
+  static Stream<SaveGameSummary?> watchSummary(SaveFolder folder) {
+    final controller = StreamController<SaveGameSummary?>.broadcast();
+    StreamSubscription<FileSystemEvent>? sub;
+
+    Future<void> emit() async {
+      try {
+        final summary = await readSummaryFromFolder(folder);
+        if (!controller.isClosed) {
+          controller.add(summary);
+        }
+      } catch (e) {
+        if (!controller.isClosed) {
+          controller.addError(e);
+        }
+      }
+    }
+
+    void startWatch() {
+      emit();
+      final dir = Directory(folder.folderPath);
+      if (!dir.existsSync()) return;
+      final targetNames = <String>{};
+      if (folder.infoFilePath != null) {
+        targetNames.add(File(folder.infoFilePath!).uri.pathSegments.last);
+      }
+      if (folder.mainFilePath != null) {
+        targetNames.add(File(folder.mainFilePath!).uri.pathSegments.last);
+      }
+      sub = dir
+          .watch(events: FileSystemEvent.modify | FileSystemEvent.create)
+          .listen((event) {
+        final eventName = File(event.path).uri.pathSegments.last;
+        if (targetNames.isEmpty || targetNames.contains(eventName)) {
+          emit();
+        }
+      });
+    }
+
+    controller
+      ..onListen = startWatch
+      ..onCancel = () async {
+        await sub?.cancel();
+        if (!controller.hasListener) {
+          await controller.close();
+        }
+      };
+
+    return controller.stream;
   }
 }
 

--- a/lib/src/features/dashboard/application/today_controller.dart
+++ b/lib/src/features/dashboard/application/today_controller.dart
@@ -1,5 +1,11 @@
+import 'dart:async';
+import 'dart:io';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../../core/save/save_locator.dart';
+import '../../../core/save/save_models.dart';
+import '../../../core/save/save_parser.dart';
 import '../domain/models.dart';
 
 class TodayState {
@@ -19,18 +25,129 @@ class TodayController extends StateNotifier<TodayState> {
               dayOfMonth: 1,
               weather: Weather.sunny,
               spiritsMood: SpiritsMood.neutral,
+              weekday: Weekday.monday,
             ),
           ),
-        );
+        ) {
+    _init();
+  }
+  StreamSubscription<SaveGameSummary?>? _saveSub;
+
+  Future<void> _init() async {
+    try {
+      final saves = await SaveLocator.discoverSaves(includeSteamCloud: true);
+      if (!mounted) return;
+      SaveFolder? target;
+      for (final folder in saves) {
+        final hasInfo = folder.infoFilePath != null && File(folder.infoFilePath!).existsSync();
+        final hasMain = folder.mainFilePath != null && File(folder.mainFilePath!).existsSync();
+        if (hasInfo || hasMain) {
+          target = folder;
+          break;
+        }
+      }
+      target ??= saves.isNotEmpty ? saves.first : null;
+      if (target == null) return;
+      _saveSub = SaveParser.watchSummary(target).listen(
+        _applySummary,
+        onError: (_) {},
+      );
+    } catch (_) {
+      // ignore discovery errors
+    }
+  }
+
+  void _applySummary(SaveGameSummary? summary) {
+    if (!mounted || summary == null) return;
+    final info = state.info;
+    final season = _seasonFrom(summary.season) ?? info.season;
+    final day = summary.dayOfMonth ?? info.dayOfMonth;
+    final weather = _weatherFrom(summary) ?? info.weather;
+    final spirits = _spiritsFrom(summary.dailyLuck) ?? info.spiritsMood;
+    final weekday = _weekdayFromDay(day);
+    state = state.copyWith(
+      info: info.copyWith(
+        year: summary.year ?? info.year,
+        season: season,
+        dayOfMonth: day,
+        weather: weather,
+        spiritsMood: spirits,
+        weekday: weekday,
+      ),
+    );
+  }
+
+  Season? _seasonFrom(String? value) {
+    switch (value?.toLowerCase()) {
+      case 'spring':
+        return Season.spring;
+      case 'summer':
+        return Season.summer;
+      case 'fall':
+      case 'autumn':
+        return Season.fall;
+      case 'winter':
+        return Season.winter;
+    }
+    return null;
+  }
+
+  Weather? _weatherFrom(SaveGameSummary summary) {
+    final icon = summary.weatherIcon?.toLowerCase();
+    switch (icon) {
+      case 'sunny':
+      case 'sun':
+        return Weather.sunny;
+      case 'rain':
+      case 'rainy':
+        return Weather.rain;
+      case 'storm':
+      case 'lightning':
+        return Weather.storm;
+      case 'wind':
+      case 'debris':
+        return Weather.wind;
+      case 'snow':
+      case 'snowy':
+        return Weather.snow;
+    }
+    if (summary.isSnowing == true) return Weather.snow;
+    if (summary.isLightning == true) return Weather.storm;
+    if (summary.isRaining == true) return Weather.rain;
+    if (summary.isDebrisWeather == true) return Weather.wind;
+    return null;
+  }
+
+  SpiritsMood? _spiritsFrom(double? luck) {
+    if (luck == null) return null;
+    if (luck >= 0.07) return SpiritsMood.veryGood;
+    if (luck >= 0.02) return SpiritsMood.good;
+    if (luck <= -0.07) return SpiritsMood.veryBad;
+    if (luck <= -0.02) return SpiritsMood.bad;
+    return SpiritsMood.neutral;
+  }
+
+  Weekday _weekdayFromDay(int day) {
+    final length = Weekday.values.length;
+    final index = ((day - 1) % length + length) % length;
+    return Weekday.values[index];
+  }
 
   void setSeason(Season season) =>
       state = state.copyWith(info: state.info.copyWith(season: season));
-  void setDay(int day) =>
-      state = state.copyWith(info: state.info.copyWith(dayOfMonth: day));
+  void setDay(int day) => state = state.copyWith(
+        info: state.info.copyWith(dayOfMonth: day, weekday: _weekdayFromDay(day)),
+      );
   void setWeather(Weather weather) =>
       state = state.copyWith(info: state.info.copyWith(weather: weather));
   void setSpirits(SpiritsMood mood) =>
       state = state.copyWith(info: state.info.copyWith(spiritsMood: mood));
+
+  @override
+  void dispose() {
+    _saveSub?.cancel();
+    super.dispose();
+  }
 }
 
 final todayProvider =

--- a/lib/src/features/dashboard/domain/models.dart
+++ b/lib/src/features/dashboard/domain/models.dart
@@ -4,12 +4,15 @@ enum Weather { sunny, rain, storm, wind, snow }
 
 enum SpiritsMood { veryGood, good, neutral, bad, veryBad }
 
+enum Weekday { monday, tuesday, wednesday, thursday, friday, saturday, sunday }
+
 class TodayInfo {
   final int year;
   final Season season;
   final int dayOfMonth; // 1-28
   final Weather weather;
   final SpiritsMood spiritsMood;
+  final Weekday weekday;
 
   const TodayInfo({
     required this.year,
@@ -17,6 +20,7 @@ class TodayInfo {
     required this.dayOfMonth,
     required this.weather,
     required this.spiritsMood,
+    required this.weekday,
   });
 
   TodayInfo copyWith({
@@ -25,6 +29,7 @@ class TodayInfo {
     int? dayOfMonth,
     Weather? weather,
     SpiritsMood? spiritsMood,
+    Weekday? weekday,
   }) {
     return TodayInfo(
       year: year ?? this.year,
@@ -32,6 +37,7 @@ class TodayInfo {
       dayOfMonth: dayOfMonth ?? this.dayOfMonth,
       weather: weather ?? this.weather,
       spiritsMood: spiritsMood ?? this.spiritsMood,
+      weekday: weekday ?? this.weekday,
     );
   }
 }

--- a/lib/src/features/dashboard/presentation/dashboard_page.dart
+++ b/lib/src/features/dashboard/presentation/dashboard_page.dart
@@ -64,6 +64,15 @@ class _TodayCard extends ConsumerWidget {
         SpiritsMood.bad: '悪い',
         SpiritsMood.veryBad: 'とても悪い',
       }[m]!;
+  String _weekdayLabel(Weekday d) => {
+        Weekday.monday: '月',
+        Weekday.tuesday: '火',
+        Weekday.wednesday: '水',
+        Weekday.thursday: '木',
+        Weekday.friday: '金',
+        Weekday.saturday: '土',
+        Weekday.sunday: '日',
+      }[d]!;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -83,6 +92,7 @@ class _TodayCard extends ConsumerWidget {
                 Text('年: ${today.year}'),
                 Text('季節: ${_seasonLabel(today.season)}'),
                 Text('日付: ${today.dayOfMonth}日'),
+                Text('曜日: ${_weekdayLabel(today.weekday)}曜'),
                 Text('天気: ${_weatherLabel(today.weather)}'),
                 Text('精霊: ${_spiritsLabel(today.spiritsMood)}'),
               ],


### PR DESCRIPTION
## Summary
- parse additional weather, luck, and weekday data from save files
- watch save directories for XML changes and update Today info automatically
- display the current weekday alongside the existing daily status on the dashboard

## Testing
- not run (flutter / dart CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d5525511e08330b236ca59b3ebbafe